### PR TITLE
Update build-pr.yml and build-release.yml to remove support for linux/arm/v7 platform

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -81,7 +81,7 @@ jobs:
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request updates the build-pr.yml and build-release.yml files to remove support for the linux/arm/v7 platform. The platforms have been changed to linux/amd64 and linux/arm64. This change ensures that the build process only targets the specified platforms and removes unnecessary configurations for the linux/arm/v7 platform.